### PR TITLE
Add partial support for firmware v2

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "slug": "PitchGrid",
   "name": "PitchGrid Rack",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "license": "GPL-3.0-or-later",
   "brand": "PitchGrid",
   "author": "Peter Jung",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "slug": "PitchGrid",
   "name": "PitchGrid Rack",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "license": "GPL-3.0-or-later",
   "brand": "PitchGrid",
   "author": "Peter Jung",

--- a/src/MicroExquis.cpp
+++ b/src/MicroExquis.cpp
@@ -364,7 +364,9 @@ struct MicroExquis : Module {
 
 			for (int i = 0; i < 4; i++){
 				ExquisNote* note = exquis.getNoteByVoltage(pitch[i]);
-				voltage[i] = tuning.vecToVoltage(note->scaleCoord);
+				if (note) {
+					voltage[i] = tuning.vecToVoltage(note->scaleCoord);
+				}
 			}
 
 			// Set output

--- a/src/exquis.hpp
+++ b/src/exquis.hpp
@@ -258,7 +258,11 @@ struct Exquis {
 		midi_output.sendMessage(msg);
 	}
 	ExquisNote* getNoteByMidinote(uint8_t midinote){
-		return &notes[midinote - 36];
+		size_t index = midinote - 36;
+		if (index >= notes.size()) {
+			return nullptr;
+		}
+		return &notes[index];
 	}
 	ExquisNote* getNoteByVoltage(float voltage){
 		// expect V in [-5v, +5v], map 1V/octave and 0v = middle C (C4=midinote 60)

--- a/src/exquis.hpp
+++ b/src/exquis.hpp
@@ -91,15 +91,23 @@ struct ExquisNote {
 	}
 	void sendSetMidinoteMessage(midi::Output* midi_output){
 		midi::Message msg;
-		// F0 00 21 7E 04 noteId midinote F7
+		// TODO: Select firmware compatibility mode; sending both for now since v2 support is incomplete.
+		// Firmware v1: F0 00 21 7E 04 noteId midinote F7
 		msg.bytes = {0xf0, 0x00, 0x21, 0x7e, 0x04, noteId, midinote, 0xf7};
+		midi_output->sendMessage(msg);
+		// Firmware v2: F0 00 21 7E 15 noteId midinote F7
+		msg.bytes = {0xf0, 0x00, 0x21, 0x7e, 0x15, noteId, midinote, 0xf7};
 		midi_output->sendMessage(msg);
 	}
 	void sendSetColorMessage(midi::Output* midi_output, Color color){
 		midi::Message msg;
-		// F0 00 21 7E 03 noteId r g b F7
 		shownColor = color;
+		// TODO: Select firmware compatibility mode; sending both for now since v2 support is incomplete.
+		// Firmware v1: F0 00 21 7E 03 noteId r g b F7
 		msg.bytes = {0xf0, 0x00, 0x21, 0x7e, 0x03, noteId, color.r, color.g, color.b, 0xf7};
+		midi_output->sendMessage(msg);
+		// Firmware v2: F0 00 21 7E 14 noteId r g b F7
+		msg.bytes = {0xf0, 0x00, 0x21, 0x7e, 0x14, noteId, color.r, color.g, color.b, 0xf7};
 		midi_output->sendMessage(msg);
 	}
 };

--- a/src/pitchgrid_exquis.hpp
+++ b/src/pitchgrid_exquis.hpp
@@ -563,41 +563,42 @@ struct PitchGridExquis: Exquis {
 				
 				uint8_t noteId = msg.getNote();
 				
-				ExquisNote* note = getNoteByMidinote(noteId);
-				IntegerVector selectedInterval = note->scaleCoord;
-				if (selectedInterval == ZERO_VECTOR){
-					tuningConstantNoteSelected = false;
-					tuningConstantNote.stop();
-					tuningModeRetuneInterval = selectedInterval;
-					tuningRetuneNote.startWithNote(note);
-					tuningModeOn = true;
-				} else if (note->scaleSeqNr>=0 && selectedInterval.x >= 0 && selectedInterval.y >= 0 && selectedInterval.x <= scaleMapper.scale.scale_system.x && selectedInterval.y <= scaleMapper.scale.scale_system.y){
-					if (tuningConstantNoteSelected){
-						tuningConstantNoteSelected = false;
-						tuningConstantNote.stop();
-						tuningModeOn = false;
-						tuningRetuneNote.stop();
-					}
-					if (tuningModeOn){
-						if (tuningModeRetuneInterval != ZERO_VECTOR){
-							// check that selected intervals are not linearly dependent
-							if (tuningModeRetuneInterval.x * selectedInterval.y - tuningModeRetuneInterval.y * selectedInterval.x != 0){
-								tuningConstantNoteSelected = true;
-								tuningModeConstantInterval = selectedInterval;
-								tuningConstantNote.startWithNote(note);
-							}
-						}else{
-							tuningModeRetuneInterval = selectedInterval;
-							tuningRetuneNote.startWithNote(note);
-						}
-					}else{
+				if (ExquisNote* note = getNoteByMidinote(noteId)) {
+					IntegerVector selectedInterval = note->scaleCoord;
+					if (selectedInterval == ZERO_VECTOR){
 						tuningConstantNoteSelected = false;
 						tuningConstantNote.stop();
 						tuningModeRetuneInterval = selectedInterval;
 						tuningRetuneNote.startWithNote(note);
 						tuningModeOn = true;
-					}
-				} // otherwise ignore
+					} else if (note->scaleSeqNr>=0 && selectedInterval.x >= 0 && selectedInterval.y >= 0 && selectedInterval.x <= scaleMapper.scale.scale_system.x && selectedInterval.y <= scaleMapper.scale.scale_system.y){
+						if (tuningConstantNoteSelected){
+							tuningConstantNoteSelected = false;
+							tuningConstantNote.stop();
+							tuningModeOn = false;
+							tuningRetuneNote.stop();
+						}
+						if (tuningModeOn){
+							if (tuningModeRetuneInterval != ZERO_VECTOR){
+								// check that selected intervals are not linearly dependent
+								if (tuningModeRetuneInterval.x * selectedInterval.y - tuningModeRetuneInterval.y * selectedInterval.x != 0){
+									tuningConstantNoteSelected = true;
+									tuningModeConstantInterval = selectedInterval;
+									tuningConstantNote.startWithNote(note);
+								}
+							}else{
+								tuningModeRetuneInterval = selectedInterval;
+								tuningRetuneNote.startWithNote(note);
+							}
+						}else{
+							tuningConstantNoteSelected = false;
+							tuningConstantNote.stop();
+							tuningModeRetuneInterval = selectedInterval;
+							tuningRetuneNote.startWithNote(note);
+							tuningModeOn = true;
+						}
+					} // otherwise ignore
+				}
 			}
 		} else if (scaleSelectModeOn){
 			// react to button presses in scale select mode
@@ -606,11 +607,12 @@ struct PitchGridExquis: Exquis {
 				
 				uint8_t noteId = msg.getNote();
 				
-				ExquisNote* note = getNoteByMidinote(noteId);
-				ScaleVector scaleSystem = scaleSystemForNote(note);
-				if (scaleSystem.x > 0 && scaleSystem.y > 0 && scaleMapper.scale.isCoprimeScaleVector(scaleSystem)){
-					scaleMapper.scale.setScaleSystem(scaleSystem);
-					selectedScaleNote.startWithNote(note);
+				if (ExquisNote* note = getNoteByMidinote(noteId)) {
+					ScaleVector scaleSystem = scaleSystemForNote(note);
+					if (scaleSystem.x > 0 && scaleSystem.y > 0 && scaleMapper.scale.isCoprimeScaleVector(scaleSystem)){
+						scaleMapper.scale.setScaleSystem(scaleSystem);
+						selectedScaleNote.startWithNote(note);
+					}
 				}
 				showScaleSystemSelectLayer();
 			}
@@ -621,30 +623,33 @@ struct PitchGridExquis: Exquis {
 				
 				uint8_t noteId = msg.getNote();
 				
-				ExquisNote* note = getNoteByMidinote(noteId);
-				scaleMapper.moveBaseTo(note->coord);
+				if (ExquisNote* note = getNoteByMidinote(noteId)) {
+					scaleMapper.moveBaseTo(note->coord);
+				}
 				showSingleOctaveLayer();
 			}
 		}
 		if (msg.getStatus()==0x9){
 			// note on
 			uint8_t noteId = msg.getNote();
-			ExquisNote* note = getNoteByMidinote(noteId);
-			note->playing = true;
+			if (ExquisNote* note = getNoteByMidinote(noteId)) {
+				note->playing = true;
 
-			if (tuning){
-				lastNotePlayedNameLabel = scaleMapper.scale.canonicalNameForCoord(note->scaleCoord, tuning) + " (" + std::to_string(note->scaleCoord.y) + "," +  std::to_string(note->scaleCoord.x) + ")";
-				std::stringstream ss1;
-				float note_fr = tuning->vecToFreqRatioNoOffset(note->scaleCoord);
-				ss1 << std::fixed << std::setprecision(1) << 1200*log2(note_fr) << "ct"
-					<< " (" <<  contFracDisplay(note_fr) << ")";
-				lastNotePlayedLabel = ss1.str();
+				if (tuning){
+					lastNotePlayedNameLabel = scaleMapper.scale.canonicalNameForCoord(note->scaleCoord, tuning) + " (" + std::to_string(note->scaleCoord.y) + "," +  std::to_string(note->scaleCoord.x) + ")";
+					std::stringstream ss1;
+					float note_fr = tuning->vecToFreqRatioNoOffset(note->scaleCoord);
+					ss1 << std::fixed << std::setprecision(1) << 1200*log2(note_fr) << "ct"
+						<< " (" <<  contFracDisplay(note_fr) << ")";
+					lastNotePlayedLabel = ss1.str();
+				}
 			}
 		}else if (msg.getStatus()==0x8){
 			// note off
 			uint8_t noteId = msg.getNote();
-			ExquisNote* note = getNoteByMidinote(noteId);
-			note->playing = false;
+			if (ExquisNote* note = getNoteByMidinote(noteId)) {
+				note->playing = false;
+			}
 		}
 	}
 


### PR DESCRIPTION
This change adds some very basic compatibility with Exquis firmware v2. It fixes the sysex output sequences for setting note pad MIDI note numbers and note pad colors. So the lattice colors all show up and MIDI notes map correctly!

However, the input sysex signals don't appear to have all equivalents in v2. For example, turning knobs does not indicate relative turn amounts via sysex, it only sends absolute control values. And some bottom-row buttons send no signal at all. So there's just an experimental start at input handling here, it's very incomplete and full compatibility for this project may not yet be possible.